### PR TITLE
fix: prevent SIGKILL on updated secretlint binary

### DIFF
--- a/SecureClipboard/ClipboardMonitor.swift
+++ b/SecureClipboard/ClipboardMonitor.swift
@@ -90,6 +90,7 @@ final class ClipboardMonitor {
     private func scanText(_ text: String, sourceApp: String?) async {
         do {
             let result = try await scanner.scan(text: text)
+            await MainActor.run { state.lastScanError = nil }
             switch result.action {
             case .discard(let patternName):
                 logger.info("Discard pattern matched: \(patternName)")
@@ -118,12 +119,16 @@ final class ClipboardMonitor {
             }
         } catch {
             logger.error("Secret scan failed: \(error)")
+            await MainActor.run {
+                state.lastScanError = error.localizedDescription
+            }
         }
     }
 
     private func scanImage(_ image: NSImage, sourceApp: String?) async {
         do {
             let result = try await imageDetector.detect(image: image)
+            await MainActor.run { state.lastScanError = nil }
             guard result.hasSecrets else { return }
 
             switch result.scanAction {
@@ -153,6 +158,9 @@ final class ClipboardMonitor {
             }
         } catch {
             logger.error("Image secret detection failed: \(error)")
+            await MainActor.run {
+                state.lastScanError = error.localizedDescription
+            }
         }
     }
 

--- a/SecureClipboard/MenuBarView.swift
+++ b/SecureClipboard/MenuBarView.swift
@@ -49,6 +49,13 @@ struct MenuBarView: View {
             }
         }
 
+        if let scanError = state.lastScanError {
+            Divider()
+            Text("⚠ Scan error: \(scanError)")
+                .font(.caption)
+                .foregroundStyle(.red)
+        }
+
         Divider()
         if let version = state.secretlintVersion {
             Text("secretlint v\(version)")

--- a/SecureClipboard/SecretlintUpdater.swift
+++ b/SecureClipboard/SecretlintUpdater.swift
@@ -105,11 +105,40 @@ actor SecretlintUpdater {
             let attributes: [FileAttributeKey: Any] = [.posixPermissions: 0o755]
             try FileManager.default.setAttributes(attributes, ofItemAtPath: tempPath)
 
+            // Remove quarantine attribute and fix code signature
+            // Downloaded binaries may have broken LC_CODE_SIGNATURE that causes SIGKILL
+            removeQuarantine(atPath: tempPath)
+            adHocSign(atPath: tempPath)
+
+            // Verify new binary works before replacing
+            let verified = verifyBinary(atPath: tempPath)
+            guard verified else {
+                try? FileManager.default.removeItem(atPath: tempPath)
+                throw UpdateError.verificationFailed
+            }
+
             // Atomic swap
             let backupPath = binaryPath + ".bak"
             try? FileManager.default.removeItem(atPath: backupPath)
             try FileManager.default.moveItem(atPath: binaryPath, toPath: backupPath)
-            try FileManager.default.moveItem(atPath: tempPath, toPath: binaryPath)
+            do {
+                try FileManager.default.moveItem(atPath: tempPath, toPath: binaryPath)
+            } catch {
+                // Restore backup if swap fails
+                try? FileManager.default.moveItem(atPath: backupPath, toPath: binaryPath)
+                throw error
+            }
+
+            // Verify replaced binary also works (quarantine/signing might differ at final path)
+            let finalVerified = verifyBinary(atPath: binaryPath)
+            if !finalVerified {
+                // Restore backup
+                logger.error("Updated binary failed verification at final path, restoring backup")
+                try? FileManager.default.removeItem(atPath: binaryPath)
+                try? FileManager.default.moveItem(atPath: backupPath, toPath: binaryPath)
+                throw UpdateError.verificationFailed
+            }
+
             try? FileManager.default.removeItem(atPath: backupPath)
 
             logger.info("Updated secretlint: \(current) → \(latest.version)")
@@ -128,6 +157,56 @@ actor SecretlintUpdater {
             }
         }
         return nil
+    }
+
+    /// Remove macOS quarantine attribute from downloaded binary
+    private func removeQuarantine(atPath path: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xattr")
+        process.arguments = ["-cr", path]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try? process.run()
+        process.waitUntilExit()
+    }
+
+    /// Ad-hoc sign binary to fix broken or missing code signatures
+    /// Downloaded binaries may contain invalid LC_CODE_SIGNATURE which causes macOS kernel to SIGKILL
+    private func adHocSign(atPath path: String) {
+        // First remove any existing broken signature
+        let remove = Process()
+        remove.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+        remove.arguments = ["--remove-signature", path]
+        remove.standardOutput = Pipe()
+        remove.standardError = Pipe()
+        try? remove.run()
+        remove.waitUntilExit()
+
+        // Then ad-hoc sign
+        let sign = Process()
+        sign.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+        sign.arguments = ["--sign", "-", "--force", path]
+        sign.standardOutput = Pipe()
+        sign.standardError = Pipe()
+        try? sign.run()
+        sign.waitUntilExit()
+    }
+
+    /// Verify that a binary at the given path can execute --version successfully
+    private func verifyBinary(atPath path: String) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = ["--version"]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            logger.error("Binary verification failed at \(path): \(error)")
+            return false
+        }
     }
 
     private func sha256(data: Data) -> String {
@@ -155,11 +234,27 @@ enum UpdateResult {
     case failed(error: String)
 }
 
-enum UpdateError: Error {
+enum UpdateError: LocalizedError {
     case invalidResponse
     case unsupportedArchitecture(String)
     case checksumNotFound
     case checksumMismatch(expected: String, actual: String)
+    case verificationFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "Invalid response from GitHub API"
+        case .unsupportedArchitecture(let arch):
+            return "Unsupported architecture: \(arch)"
+        case .checksumNotFound:
+            return "Checksum not found in release"
+        case .checksumMismatch(let expected, let actual):
+            return "Checksum mismatch: expected \(expected), got \(actual)"
+        case .verificationFailed:
+            return "Downloaded binary failed verification (--version check failed)"
+        }
+    }
 }
 
 extension ProcessInfo {

--- a/SecureClipboard/StatusState.swift
+++ b/SecureClipboard/StatusState.swift
@@ -17,6 +17,7 @@ final class StatusState {
     var autoUpdate: Bool = true
     var secretlintVersion: String?
     var updateStatus: String?
+    var lastScanError: String?
 
     private(set) var lastOriginalText: String?
     private(set) var lastOriginalImage: NSImage?


### PR DESCRIPTION
## Summary

Downloaded secretlint binaries may contain invalid `LC_CODE_SIGNATURE` load commands, causing the macOS kernel to SIGKILL the process on execution. This PR fixes the auto-update flow to re-sign binaries and verify they work before replacing the existing binary. It also surfaces scan errors in the menu bar for easier troubleshooting.

## Changes

- Remove quarantine attribute (`xattr -cr`) from downloaded binaries
- Strip broken code signatures and ad-hoc re-sign (`codesign --sign -`) before use
- Verify the new binary executes `--version` successfully before and after replacing the existing one
- Restore backup binary if verification fails at the final path
- Add `lastScanError` to `StatusState` and display it in the menu bar dropdown
- Make `UpdateError` conform to `LocalizedError` with descriptive error messages
- Add new `verificationFailed` error case

## Breaking Changes

None

## Test Plan

- Build with `swift build --disable-sandbox` and verify no compilation errors
- Trigger a secretlint auto-update and confirm the new binary is properly signed and verified
- Simulate a broken binary to confirm rollback to backup works
- Verify scan errors appear in the menu bar when secretlint fails
