### PR TITLE
fix: use temporary file for secretlint config to avoid NFD Unicode normalization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 
 - `AppState` (singleton) holds `StatusState` and `ClipboardMonitor`, ensuring they outlive SwiftUI struct lifecycle
 - `ClipboardMonitor` uses `Thread.detachNewThread` for polling — `Timer` and `DispatchSource` don't fire reliably from SwiftUI App `init()`
-- `SecretScanner` calls secretlint binary via `Process` subprocess with `--format=mask-result` and `--secretlintrcJSON`
+- `SecretScanner` calls secretlint binary via `Process` subprocess with `--format=mask-result` and `--secretlintrc` (config written to temp file to avoid macOS NFD normalization of Process arguments)
 - `ImageSecretDetector` uses Vision OCR to extract text + bounding boxes, then `SecretScanner` checks for secrets
 - `ClipboardRewriter` redacts image secrets using CICrystallize + CIGaussianBlur with background color fill
 - `SecretlintUpdater` checks GitHub API for new releases on app launch

--- a/SecureClipboard/SecretScanner.swift
+++ b/SecureClipboard/SecretScanner.swift
@@ -77,7 +77,7 @@ actor SecretScanner {
         // Write config to a temporary file instead of passing via --secretlintrcJSON argument.
         // macOS Process.arguments converts strings to NFD (Unicode decomposed form),
         // which breaks regex patterns containing characters like ビ (NFC) → ヒ+゙ (NFD).
-        let tmpConfigPath = NSTemporaryDirectory() + "secretlintrc-\(ProcessInfo.processInfo.processIdentifier).json"
+        let tmpConfigPath = NSTemporaryDirectory() + "secretlintrc-\(UUID().uuidString).json"
         try configJSON.write(toFile: tmpConfigPath, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(atPath: tmpConfigPath) }
 

--- a/SecureClipboard/SecretScanner.swift
+++ b/SecureClipboard/SecretScanner.swift
@@ -74,12 +74,19 @@ actor SecretScanner {
     }
 
     private func runSecretlint(input: String, format: String, configJSON: String) async throws -> String {
+        // Write config to a temporary file instead of passing via --secretlintrcJSON argument.
+        // macOS Process.arguments converts strings to NFD (Unicode decomposed form),
+        // which breaks regex patterns containing characters like ビ (NFC) → ヒ+゙ (NFD).
+        let tmpConfigPath = NSTemporaryDirectory() + "secretlintrc-\(ProcessInfo.processInfo.processIdentifier).json"
+        try configJSON.write(toFile: tmpConfigPath, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: tmpConfigPath) }
+
         let process = Process()
         process.executableURL = URL(fileURLWithPath: binaryPath)
         process.arguments = [
             "--stdinFileName", "clipboard.txt",
             "--format", format,
-            "--secretlintrcJSON", configJSON
+            "--secretlintrc", tmpConfigPath
         ]
 
         let inputPipe = Pipe()

--- a/SecureClipboardTests/SecretScannerTests.swift
+++ b/SecureClipboardTests/SecretScannerTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import SecureClipboard
 
-private func makeScannerWithBinary() -> SecretScanner {
+private func makeScannerWithBinary(configJSON: String? = nil) -> SecretScanner {
     // The binary is at SecureClipboard/Resources/secretlint relative to the repo root.
     // Use #filePath to locate the repo root from the test file path.
     let testFilePath = URL(fileURLWithPath: #filePath)
@@ -14,7 +14,7 @@ private func makeScannerWithBinary() -> SecretScanner {
         .appendingPathComponent("Resources")
         .appendingPathComponent("secretlint")
         .path
-    return SecretScanner(binaryPath: binaryPath)
+    return SecretScanner(binaryPath: binaryPath, configJSON: configJSON)
 }
 
 /// Build a Slack token string at runtime to avoid triggering the pre-commit secretlint check.
@@ -29,6 +29,16 @@ private func slackTokenText() -> String {
     let result = try await scanner.scan(text: "hello world")
     #expect(result.hasSecrets == false)
     #expect(result.maskedText == "hello world")
+}
+
+/// Verify that Japanese regex patterns with dakuten characters (e.g. ガ, ビ, ゾ)
+/// work correctly despite macOS Process.arguments converting to NFD.
+@Test func scanTextWithJapanesePattern() async throws {
+    let configJSON = #"{"rules":[{"id":"@secretlint/secretlint-rule-pattern","options":{"patterns":[{"name":"test-dakuten","pattern":"/ダミーデータ/i"}]}}]}"#
+    let scanner = makeScannerWithBinary(configJSON: configJSON)
+    let result = try await scanner.scan(text: "これはダミーデータです")
+    #expect(result.hasSecrets == true)
+    #expect(result.maskedText.contains("*"))
 }
 
 @Test func scanTextWithSlackToken() async throws {


### PR DESCRIPTION
## Summary

macOS `Process.arguments` converts strings to NFD (Unicode decomposed form), which breaks regex patterns containing composed characters like ビ (NFC → ヒ+゙ NFD). This PR writes the secretlint config to a temporary file and passes it via `--secretlintrc` instead of the `--secretlintrcJSON` argument, preserving the original NFC encoding.

## Changes

- Write `configJSON` to a temporary file (`secretlintrc-<pid>.json`) instead of passing as a command-line argument
- Use `--secretlintrc <path>` instead of `--secretlintrcJSON <json>`
- Clean up the temporary file with `defer`

## Breaking Changes

None

## Test Plan

- Verify secretlint scanning still works for text and image clipboard content
- Test with custom mask patterns containing Japanese characters (e.g., カタカナ regex)
- Confirm temporary file is cleaned up after each scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)