### PR TITLE
feat: improve OCR accuracy with revision 3 and auto language detection

### DIFF
--- a/SecureClipboard/ImageSecretDetector.swift
+++ b/SecureClipboard/ImageSecretDetector.swift
@@ -40,6 +40,8 @@ actor ImageSecretDetector {
                 continuation.resume(returning: observations)
             }
             request.recognitionLevel = .accurate
+            request.revision = VNRecognizeTextRequestRevision3
+            request.automaticallyDetectsLanguage = true
 
             let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
             do {


### PR DESCRIPTION
## Summary

Improve image OCR accuracy by using VNRecognizeTextRequestRevision3 and enabling automatic language detection in the Vision framework text recognition request.

## Changes

- Set `request.revision` to `VNRecognizeTextRequestRevision3` for the latest and most accurate text recognition model
- Enable `request.automaticallyDetectsLanguage` so Vision can detect the language of text in images without requiring manual specification

## Breaking Changes

None

## Test Plan

- Copy an image containing secret-like text (e.g., API keys) to the clipboard
- Verify that OCR detection still works correctly and secrets are masked
- Test with images containing non-English text to verify improved language detection