### PR TITLE
feat: add scanDelaySeconds config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ Custom patterns with two actions:
 
 Patterns use `/regex/flags` syntax. Supported flags: `i` (case-insensitive), `m` (multiline), `s` (dotAll).
 
+### maskDelaySeconds
+
+Seconds to wait before scanning clipboard content. Default: `0` (immediate). During the delay, the raw value remains in the clipboard for normal paste operations. If the clipboard changes during the delay, the previous scan is cancelled.
+
+```json
+{
+    "maskDelaySeconds": 5
+}
+```
+
 ### skipScanAppIdentifiers
 
 Bundle identifiers of apps to skip scanning for. Clipboard changes from these apps are not scanned. Useful for password managers like 1Password.

--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ Custom patterns with two actions:
 
 Patterns use `/regex/flags` syntax. Supported flags: `i` (case-insensitive), `m` (multiline), `s` (dotAll).
 
-### maskDelaySeconds
+### scanDelaySeconds
 
 Seconds to wait before scanning clipboard content. Default: `0` (immediate). During the delay, the raw value remains in the clipboard for normal paste operations. If the clipboard changes during the delay, the previous scan is cancelled.
 
 ```json
 {
-    "maskDelaySeconds": 5
+    "scanDelaySeconds": 5
 }
 ```
 

--- a/SecureClipboard/AppConfig.swift
+++ b/SecureClipboard/AppConfig.swift
@@ -6,7 +6,7 @@ struct AppConfig: Codable {
     var rules: [SecretlintRule]
     var patterns: [Pattern]?
     var skipScanAppIdentifiers: [String]?
-    var maskDelaySeconds: Double?
+    var scanDelaySeconds: Double?
 
     struct SecretlintRule: Codable {
         let id: String
@@ -32,7 +32,7 @@ struct AppConfig: Codable {
         ],
         patterns: nil,
         skipScanAppIdentifiers: nil,
-        maskDelaySeconds: nil
+        scanDelaySeconds: nil
     )
 
     /// Load config from disk, falling back to defaults

--- a/SecureClipboard/AppConfig.swift
+++ b/SecureClipboard/AppConfig.swift
@@ -6,6 +6,7 @@ struct AppConfig: Codable {
     var rules: [SecretlintRule]
     var patterns: [Pattern]?
     var skipScanAppIdentifiers: [String]?
+    var maskDelaySeconds: Double?
 
     struct SecretlintRule: Codable {
         let id: String
@@ -30,7 +31,8 @@ struct AppConfig: Codable {
             SecretlintRule(id: "@secretlint/secretlint-rule-preset-recommend", options: nil)
         ],
         patterns: nil,
-        skipScanAppIdentifiers: nil
+        skipScanAppIdentifiers: nil,
+        maskDelaySeconds: nil
     )
 
     /// Load config from disk, falling back to defaults

--- a/SecureClipboard/ClipboardMonitor.swift
+++ b/SecureClipboard/ClipboardMonitor.swift
@@ -61,6 +61,16 @@ final class ClipboardMonitor {
                         continue
                     }
 
+                    // Delay masking if configured (default: 0 = immediate)
+                    let delay = config.maskDelaySeconds ?? 0
+                    if delay > 0 {
+                        Thread.sleep(forTimeInterval: delay)
+                        // If clipboard changed during delay, skip this scan
+                        if pasteboard.changeCount != current {
+                            continue
+                        }
+                    }
+
                     if let text = pasteboard.string(forType: .string), !text.isEmpty {
                         let semaphore = DispatchSemaphore(value: 0)
                         Task {

--- a/SecureClipboard/ClipboardMonitor.swift
+++ b/SecureClipboard/ClipboardMonitor.swift
@@ -61,8 +61,8 @@ final class ClipboardMonitor {
                         continue
                     }
 
-                    // Delay masking if configured (default: 0 = immediate)
-                    let delay = config.maskDelaySeconds ?? 0
+                    // Delay scanning if configured (default: 0 = immediate)
+                    let delay = config.scanDelaySeconds ?? 0
                     if delay > 0 {
                         Thread.sleep(forTimeInterval: delay)
                         // If clipboard changed during delay, skip this scan

--- a/SecureClipboard/MenuBarView.swift
+++ b/SecureClipboard/MenuBarView.swift
@@ -13,7 +13,8 @@ struct MenuBarView: View {
             }
         ],
         "patterns": [],
-        "skipScanAppIdentifiers": []
+        "skipScanAppIdentifiers": [],
+        "maskDelaySeconds": 0
     }
     """
 

--- a/SecureClipboard/MenuBarView.swift
+++ b/SecureClipboard/MenuBarView.swift
@@ -14,7 +14,7 @@ struct MenuBarView: View {
         ],
         "patterns": [],
         "skipScanAppIdentifiers": [],
-        "maskDelaySeconds": 0
+        "scanDelaySeconds": 0
     }
     """
 

--- a/SecureClipboardTests/AppConfigTests.swift
+++ b/SecureClipboardTests/AppConfigTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import SecureClipboard
 
@@ -122,6 +123,27 @@ import Testing
         ]
     )
     #expect(config.matchesDiscardPattern("this is CONFIDENTIAL info")?.name == "ng")
+}
+
+@Test func maskDelaySecondsDefaultIsNil() {
+    let config = AppConfig.default
+    #expect(config.maskDelaySeconds == nil)
+}
+
+@Test func maskDelaySecondsParsesFromJSON() throws {
+    let json = """
+    {"rules":[],"maskDelaySeconds":15}
+    """
+    let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+    #expect(config.maskDelaySeconds == 15)
+}
+
+@Test func maskDelaySecondsOptionalInJSON() throws {
+    let json = """
+    {"rules":[]}
+    """
+    let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+    #expect(config.maskDelaySeconds == nil)
 }
 
 @Test func matchesDiscardPatternIgnoresMask() {

--- a/SecureClipboardTests/AppConfigTests.swift
+++ b/SecureClipboardTests/AppConfigTests.swift
@@ -125,25 +125,25 @@ import Testing
     #expect(config.matchesDiscardPattern("this is CONFIDENTIAL info")?.name == "ng")
 }
 
-@Test func maskDelaySecondsDefaultIsNil() {
+@Test func scanDelaySecondsDefaultIsNil() {
     let config = AppConfig.default
-    #expect(config.maskDelaySeconds == nil)
+    #expect(config.scanDelaySeconds == nil)
 }
 
-@Test func maskDelaySecondsParsesFromJSON() throws {
+@Test func scanDelaySecondsParsesFromJSON() throws {
     let json = """
-    {"rules":[],"maskDelaySeconds":15}
+    {"rules":[],"scanDelaySeconds":15}
     """
     let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
-    #expect(config.maskDelaySeconds == 15)
+    #expect(config.scanDelaySeconds == 15)
 }
 
-@Test func maskDelaySecondsOptionalInJSON() throws {
+@Test func scanDelaySecondsOptionalInJSON() throws {
     let json = """
     {"rules":[]}
     """
     let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
-    #expect(config.maskDelaySeconds == nil)
+    #expect(config.scanDelaySeconds == nil)
 }
 
 @Test func matchesDiscardPatternIgnoresMask() {


### PR DESCRIPTION
## Summary

Add `scanDelaySeconds` config option to delay clipboard scanning by N seconds after copy. During the delay, the raw clipboard value remains available for normal paste operations. If the clipboard changes during the delay, the previous scan is cancelled. Default is `0` (immediate scanning, no behavior change).

Does not affect `secure-pbcopy` CLI (IPC path always scans immediately).

## Changes

- `AppConfig`: add `scanDelaySeconds: Double?` field (default `nil` = immediate)
- `ClipboardMonitor`: sleep before scan when `scanDelaySeconds > 0`, re-check `changeCount` after delay to cancel stale scans
- `MenuBarView`: include `scanDelaySeconds` in default config template
- `README`: document `scanDelaySeconds` option with usage example
- `AppConfigTests`: add unit tests for parsing, default value, and optional handling

## Breaking Changes

None

## Test plan

- [ ] Verify default behavior unchanged (`scanDelaySeconds: 0` or omitted)
- [ ] Set `scanDelaySeconds: 15`, copy a secret, paste within 15s → raw value available
- [ ] Wait 15s after copy → clipboard is masked
- [ ] Copy again during delay → previous scan cancelled, new delay starts
- [ ] `secure-pbcopy` still scans immediately regardless of setting
- [ ] Run `swift test --disable-sandbox` → all tests pass

close https://github.com/secretlint/secure-clipboard/issues/7
