### PR TITLE
feat: support allows field on custom patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,23 @@ Custom patterns with two actions:
 
 Patterns use `/regex/flags` syntax. Supported flags: `i` (case-insensitive), `m` (multiline), `s` (dotAll).
 
+Each pattern can also take an optional `allows` array of regexes. Matches that overlap any `allows` regex are excluded from detection (same semantics as secretlint's `allows`).
+
+```json
+{
+    "patterns": [
+        {
+            "name": "discard-aaa",
+            "pattern": "/aaa/",
+            "action": "discard",
+            "allows": ["/https?:\\/\\/[^\\s]*aaa/"]
+        }
+    ]
+}
+```
+
+In the example above, bare `aaa` discards the clipboard, but `aaa` inside a URL is allowed.
+
 ### scanDelaySeconds
 
 Seconds to wait before scanning clipboard content. Default: `0` (immediate). During the delay, the raw value remains in the clipboard for normal paste operations. If the clipboard changes during the delay, the previous scan is cancelled.

--- a/SecureClipboard/AppConfig.swift
+++ b/SecureClipboard/AppConfig.swift
@@ -22,6 +22,14 @@ struct AppConfig: Codable {
         let name: String
         let pattern: String
         let action: PatternAction
+        let allows: [String]?
+
+        init(name: String, pattern: String, action: PatternAction, allows: [String]? = nil) {
+            self.name = name
+            self.pattern = pattern
+            self.action = action
+            self.allows = allows
+        }
     }
 
     static let configPath = NSHomeDirectory() + "/.config/secure-clipboard/config.json"
@@ -61,7 +69,11 @@ struct AppConfig: Codable {
         let maskPatterns = (patterns ?? []).filter { $0.action == .mask }
         if !maskPatterns.isEmpty {
             let patternOptions: [[String: Any]] = maskPatterns.map { p in
-                ["name": p.name, "pattern": p.pattern]
+                var dict: [String: Any] = ["name": p.name, "pattern": p.pattern]
+                if let allows = p.allows, !allows.isEmpty {
+                    dict["allows"] = allows
+                }
+                return dict
             }
             allRules.append([
                 "id": "@secretlint/secretlint-rule-pattern",
@@ -80,12 +92,24 @@ struct AppConfig: Codable {
     /// Check if text matches any discard pattern (Swift-side regex)
     func matchesDiscardPattern(_ text: String) -> Pattern? {
         guard let patterns else { return nil }
+        let fullRange = NSRange(text.startIndex..., in: text)
         for pattern in patterns where pattern.action == .discard {
             let (regexString, options) = parseRegex(pattern.pattern)
-            if let regex = try? NSRegularExpression(pattern: regexString, options: options),
-               regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)) != nil {
-                return pattern
+            guard let regex = try? NSRegularExpression(pattern: regexString, options: options) else { continue }
+            let matches = regex.matches(in: text, range: fullRange)
+            guard !matches.isEmpty else { continue }
+
+            let allowRanges: [NSRange] = (pattern.allows ?? [])
+                .compactMap { allowPattern -> NSRegularExpression? in
+                    let (r, o) = parseRegex(allowPattern)
+                    return try? NSRegularExpression(pattern: r, options: o)
+                }
+                .flatMap { $0.matches(in: text, range: fullRange).map { $0.range } }
+
+            let hasNonAllowedMatch = matches.contains { m in
+                !allowRanges.contains { NSIntersectionRange(m.range, $0).length > 0 }
             }
+            if hasNonAllowedMatch { return pattern }
         }
         return nil
     }

--- a/SecureClipboardTests/AppConfigTests.swift
+++ b/SecureClipboardTests/AppConfigTests.swift
@@ -216,3 +216,66 @@ import Testing
         nspasteboardSource: "com.example.App"
     ) == false)
 }
+
+@Test func secretlintrcJSONIncludesPatternAllows() {
+    let config = AppConfig(
+        rules: [],
+        patterns: [
+            .init(
+                name: "aaa-token",
+                pattern: "/aaa/",
+                action: .mask,
+                allows: ["/https?:\\/\\/[^\\s]*aaa/"]
+            )
+        ]
+    )
+    let json = config.secretlintrcJSON()
+    #expect(json.contains("aaa-token"))
+    #expect(json.contains("\"allows\""))
+    #expect(json.contains("https"))
+}
+
+@Test func secretlintrcJSONOmitsAllowsWhenNil() {
+    let config = AppConfig(
+        rules: [],
+        patterns: [
+            .init(name: "x", pattern: "/TOKEN/", action: .mask)
+        ]
+    )
+    let json = config.secretlintrcJSON()
+    #expect(json.contains("\"allows\"") == false)
+}
+
+@Test func matchesDiscardPatternRespectsAllows() {
+    let config = AppConfig(
+        rules: [],
+        patterns: [
+            .init(
+                name: "ng",
+                pattern: "/aaa/",
+                action: .discard,
+                allows: ["/https?:\\/\\/[^\\s]*aaa/"]
+            )
+        ]
+    )
+    // 裸のaaaはdiscard対象
+    #expect(config.matchesDiscardPattern("plain aaa here")?.name == "ng")
+    // URL中のaaaはallowされる
+    #expect(config.matchesDiscardPattern("see https://example.com/aaa for details") == nil)
+}
+
+@Test func matchesDiscardPatternAllowsOnlyOverlapping() {
+    let config = AppConfig(
+        rules: [],
+        patterns: [
+            .init(
+                name: "ng",
+                pattern: "/aaa/",
+                action: .discard,
+                allows: ["/https?:\\/\\/[^\\s]*aaa/"]
+            )
+        ]
+    )
+    // URL中のaaaは許可されても、別の場所の裸のaaaはdiscard対象
+    #expect(config.matchesDiscardPattern("url https://example.com/aaa and plain aaa")?.name == "ng")
+}


### PR DESCRIPTION
## Summary

Adds support for an `allows` field on custom patterns in the user config, allowing users to whitelist specific strings that should not be flagged by a custom pattern. This mirrors secretlint's built-in `allows` functionality.

## Changes

- Add `allows: [String]?` field to custom pattern model in `AppConfig.swift`
- Pass `allows` through to the generated secretlint config when present
- Add tests covering parsing and serialization of the new field in `AppConfigTests.swift`

## Breaking Changes

None. The `allows` field is optional and existing configs continue to work unchanged.

## Test Plan

- `swift test --disable-sandbox` passes including new `AppConfigTests` cases
- Manually add a custom pattern with `allows: ["example-token"]` to `~/.config/secure-clipboard/config.json` and verify that the whitelisted string is not masked while other matches still are