### PR TITLE
feat: add clearClipboardAfterSeconds auto-clear option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Config file: `~/.config/secure-clipboard/config.json` (open via menu: "Open conf
         "com.1password.1password",
         "com.runningwithcrayons.alfred.clipping"
     ],
-    "scanDelaySeconds": 0
+    "scanDelaySeconds": 0,
+    "clearClipboardAfterSeconds": null
 }
 ```
 
@@ -120,6 +121,16 @@ Seconds to wait before scanning clipboard content. Default: `0` (immediate). Dur
 ```json
 {
     "scanDelaySeconds": 5
+}
+```
+
+### clearClipboardAfterSeconds
+
+Seconds after the last clipboard change before the clipboard is automatically cleared. Default: `null` (disabled). This helps avoid accidentally pasting stale content copied earlier. The timer effectively resets on every clipboard change: if you copy something new within the interval, only the latest content is cleared. Set to `null` or `0` to disable.
+
+```json
+{
+    "clearClipboardAfterSeconds": 60
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Seconds after the last clipboard change before the clipboard is automatically cl
 }
 ```
 
+This applies to all clipboard changes, including copies from apps listed in `skipScanAppIdentifiers` (those copies are not scanned, but are still cleared). It does not affect "Copy Original Text" / "Copy Original Image", which keep their own fixed 90-second auto-clear window.
+
 ### skipScanAppIdentifiers
 
 Identifiers to skip scanning for. Each value is matched against:

--- a/SecureClipboard/AppConfig.swift
+++ b/SecureClipboard/AppConfig.swift
@@ -7,6 +7,7 @@ struct AppConfig: Codable {
     var patterns: [Pattern]?
     var skipScanAppIdentifiers: [String]?
     var scanDelaySeconds: Double?
+    var clearClipboardAfterSeconds: Double?
 
     struct SecretlintRule: Codable {
         let id: String
@@ -40,7 +41,8 @@ struct AppConfig: Codable {
         ],
         patterns: nil,
         skipScanAppIdentifiers: nil,
-        scanDelaySeconds: nil
+        scanDelaySeconds: nil,
+        clearClipboardAfterSeconds: nil
     )
 
     /// Load config from disk, falling back to defaults

--- a/SecureClipboard/ClipboardMonitor.swift
+++ b/SecureClipboard/ClipboardMonitor.swift
@@ -112,7 +112,7 @@ final class ClipboardMonitor {
     func performClipboardClearIfUnchanged(capturedChangeCount: Int) {
         let pasteboard = NSPasteboard.general
         guard pasteboard.changeCount == capturedChangeCount else { return }
-        guard pasteboard.types?.isEmpty == false else { return }
+        guard let types = pasteboard.types, !types.isEmpty else { return }
 
         pasteboard.clearContents()
         let newChangeCount = pasteboard.changeCount

--- a/SecureClipboard/ClipboardMonitor.swift
+++ b/SecureClipboard/ClipboardMonitor.swift
@@ -106,6 +106,30 @@ final class ClipboardMonitor {
         isRunning = false
     }
 
+    /// Clear the clipboard only if it hasn't changed since `capturedChangeCount`
+    /// and is not already empty. Records the clear as an own-change so the
+    /// monitor does not re-detect it (prevents an infinite clear loop).
+    func performClipboardClearIfUnchanged(capturedChangeCount: Int) {
+        let pasteboard = NSPasteboard.general
+        guard pasteboard.changeCount == capturedChangeCount else { return }
+        guard pasteboard.types?.isEmpty == false else { return }
+
+        pasteboard.clearContents()
+        let newChangeCount = pasteboard.changeCount
+        recordOwnChange(changeCount: newChangeCount)
+        lastChangeCount = newChangeCount
+        logger.info("Clipboard auto-cleared")
+    }
+
+    /// Schedule an auto-clear after `seconds`, keyed to the current changeCount.
+    private func scheduleClearIfEnabled(_ config: AppConfig) {
+        guard let seconds = config.clearClipboardAfterSeconds, seconds > 0 else { return }
+        let captured = NSPasteboard.general.changeCount
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) { [weak self] in
+            self?.performClipboardClearIfUnchanged(capturedChangeCount: captured)
+        }
+    }
+
     private func scanText(_ text: String, sourceApp: String?) async {
         do {
             let result = try await scanner.scan(text: text)

--- a/SecureClipboard/ClipboardMonitor.swift
+++ b/SecureClipboard/ClipboardMonitor.swift
@@ -66,6 +66,8 @@ final class ClipboardMonitor {
                         pasteboardTypes: pasteboardTypes,
                         nspasteboardSource: nspasteboardSource
                     ) {
+                        // Scan is skipped, but stale content should still auto-clear.
+                        self.scheduleClearIfEnabled(config)
                         Thread.sleep(forTimeInterval: 0.5)
                         continue
                     }
@@ -96,6 +98,10 @@ final class ClipboardMonitor {
                         }
                         semaphore.wait()
                     }
+
+                    // Schedule auto-clear keyed to the post-scan changeCount
+                    // (covers external copies and SecureClipboard's own masked writes).
+                    self.scheduleClearIfEnabled(config)
                 }
                 Thread.sleep(forTimeInterval: 0.5)
             }

--- a/SecureClipboard/MenuBarView.swift
+++ b/SecureClipboard/MenuBarView.swift
@@ -14,7 +14,8 @@ struct MenuBarView: View {
         ],
         "patterns": [],
         "skipScanAppIdentifiers": [],
-        "scanDelaySeconds": 0
+        "scanDelaySeconds": 0,
+        "clearClipboardAfterSeconds": null
     }
     """
 

--- a/SecureClipboardTests/AppConfigTests.swift
+++ b/SecureClipboardTests/AppConfigTests.swift
@@ -279,3 +279,24 @@ import Testing
     // URL中のaaaは許可されても、別の場所の裸のaaaはdiscard対象
     #expect(config.matchesDiscardPattern("url https://example.com/aaa and plain aaa")?.name == "ng")
 }
+
+@Test func clearClipboardAfterSecondsDefaultIsNil() {
+    let config = AppConfig.default
+    #expect(config.clearClipboardAfterSeconds == nil)
+}
+
+@Test func clearClipboardAfterSecondsParsesFromJSON() throws {
+    let json = """
+    {"rules":[],"clearClipboardAfterSeconds":60}
+    """
+    let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+    #expect(config.clearClipboardAfterSeconds == 60)
+}
+
+@Test func clearClipboardAfterSecondsOptionalInJSON() throws {
+    let json = """
+    {"rules":[]}
+    """
+    let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+    #expect(config.clearClipboardAfterSeconds == nil)
+}

--- a/SecureClipboardTests/ClipboardMonitorTests.swift
+++ b/SecureClipboardTests/ClipboardMonitorTests.swift
@@ -32,4 +32,50 @@ struct ClipboardMonitorTests {
         let hasChanged = monitor.hasClipboardChanged(since: currentChangeCount - 1)
         #expect(hasChanged == false)
     }
+
+    @Test func clearsWhenChangeCountMatches() async throws {
+        let monitor = ClipboardMonitor()
+        let pasteboard = NSPasteboard.general
+
+        pasteboard.clearContents()
+        pasteboard.setString("stale content", forType: .string)
+        let captured = pasteboard.changeCount
+
+        monitor.performClipboardClearIfUnchanged(capturedChangeCount: captured)
+
+        #expect(pasteboard.string(forType: .string) == nil)
+        // クリア書き込みは自己書き込みとして記録され、再検出されない
+        #expect(monitor.hasClipboardChanged(since: captured) == false)
+    }
+
+    @Test func doesNotClearWhenChangeCountStale() async throws {
+        let monitor = ClipboardMonitor()
+        let pasteboard = NSPasteboard.general
+
+        pasteboard.clearContents()
+        pasteboard.setString("old", forType: .string)
+        let stale = pasteboard.changeCount
+
+        // captured より後に新しい内容がコピーされた状況を再現
+        pasteboard.clearContents()
+        pasteboard.setString("new content", forType: .string)
+
+        monitor.performClipboardClearIfUnchanged(capturedChangeCount: stale)
+
+        // 最新の内容は消えない（no-op）
+        #expect(pasteboard.string(forType: .string) == "new content")
+    }
+
+    @Test func doesNotClearWhenAlreadyEmpty() async throws {
+        let monitor = ClipboardMonitor()
+        let pasteboard = NSPasteboard.general
+
+        pasteboard.clearContents()
+        let captured = pasteboard.changeCount
+
+        monitor.performClipboardClearIfUnchanged(capturedChangeCount: captured)
+
+        // 空のまま no-op（changeCount を無駄に変動させない）
+        #expect(pasteboard.changeCount == captured)
+    }
 }

--- a/docs/superpowers/plans/2026-05-31-clipboard-auto-clear.md
+++ b/docs/superpowers/plans/2026-05-31-clipboard-auto-clear.md
@@ -1,0 +1,423 @@
+# クリップボード自動クリア機能 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 最後のクリップボード変更からN秒経過したら自動でクリップボードをクリアする設定オプション (`clearClipboardAfterSeconds`) を追加する。
+
+**Architecture:** `AppConfig` に optional な `clearClipboardAfterSeconds` を追加し、`ClipboardMonitor` のポーリングループで変更検出時に「N秒後クリア」を予約する。クリア発火時は予約時に捕捉した `changeCount` と現在値が一致するときだけ `clearContents()` を実行する（changeCount ガード方式、`copyOriginalText` と同じイディオム）。クリア書き込みは `recordOwnChange` で自己書き込みとして記録し、無限クリアループを防ぐ。
+
+**Tech Stack:** Swift / Swift Package Manager / swift-testing (`import Testing`) / AppKit (`NSPasteboard`)
+
+**Build/Test commands:** `swift build --disable-sandbox` / `swift test --disable-sandbox`
+
+---
+
+## File Structure
+
+- `SecureClipboard/AppConfig.swift` — `clearClipboardAfterSeconds: Double?` フィールド追加、`default` に反映。
+- `SecureClipboard/ClipboardMonitor.swift` — クリア予約・実行ロジック追加、ポーリングループに呼び出し追加。
+- `SecureClipboardTests/AppConfigTests.swift` — 新フィールドのデコード/デフォルトのテスト追加。
+- `SecureClipboardTests/ClipboardMonitorTests.swift` — クリア実行ロジック (`performClipboardClearIfUnchanged`) のテスト追加。
+- `SecureClipboard/MenuBarView.swift` — `defaultConfig` テンプレートに新キー追記。
+- `README.md` — config 例と新セクション追記。
+
+---
+
+## Task 1: AppConfig に clearClipboardAfterSeconds を追加
+
+**Files:**
+- Modify: `SecureClipboard/AppConfig.swift`
+- Test: `SecureClipboardTests/AppConfigTests.swift`
+
+`AppConfig` は memberwise initializer と Codable を合成で利用している。optional プロパティは memberwise init で省略可能（既存の `scanDelaySeconds` と同じ）。Codable は欠落キーを `nil` にデコードする。
+
+- [ ] **Step 1: Write the failing tests**
+
+`SecureClipboardTests/AppConfigTests.swift` の末尾（最後の `}` の前ではなくファイル末尾、トップレベル `@Test` 関数群と同じ並び）に追加:
+
+```swift
+@Test func clearClipboardAfterSecondsDefaultIsNil() {
+    let config = AppConfig.default
+    #expect(config.clearClipboardAfterSeconds == nil)
+}
+
+@Test func clearClipboardAfterSecondsParsesFromJSON() throws {
+    let json = """
+    {"rules":[],"clearClipboardAfterSeconds":60}
+    """
+    let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+    #expect(config.clearClipboardAfterSeconds == 60)
+}
+
+@Test func clearClipboardAfterSecondsOptionalInJSON() throws {
+    let json = """
+    {"rules":[]}
+    """
+    let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+    #expect(config.clearClipboardAfterSeconds == nil)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --disable-sandbox --filter clearClipboardAfterSeconds`
+Expected: コンパイルエラー（`clearClipboardAfterSeconds` is not a member of `AppConfig`）。
+
+- [ ] **Step 3: Add the field to AppConfig**
+
+`SecureClipboard/AppConfig.swift` のプロパティ宣言（`var scanDelaySeconds: Double?` の直後）に追加:
+
+```swift
+    var scanDelaySeconds: Double?
+    var clearClipboardAfterSeconds: Double?
+```
+
+`AppConfig.default` に明示的に `nil` を渡す（既存の `scanDelaySeconds: nil` の直後に追加）:
+
+```swift
+    static let `default` = AppConfig(
+        rules: [
+            SecretlintRule(id: "@secretlint/secretlint-rule-preset-recommend", options: nil)
+        ],
+        patterns: nil,
+        skipScanAppIdentifiers: nil,
+        scanDelaySeconds: nil,
+        clearClipboardAfterSeconds: nil
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --disable-sandbox --filter clearClipboardAfterSeconds`
+Expected: PASS（3テスト）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add SecureClipboard/AppConfig.swift SecureClipboardTests/AppConfigTests.swift
+git commit -m "feat: add clearClipboardAfterSeconds config option"
+```
+
+---
+
+## Task 2: ClipboardMonitor にクリア実行ロジックを追加
+
+**Files:**
+- Modify: `SecureClipboard/ClipboardMonitor.swift`
+- Test: `SecureClipboardTests/ClipboardMonitorTests.swift`
+
+`performClipboardClearIfUnchanged(capturedChangeCount:)` は同期メソッドで、changeCount ガードと空チェックを行い、クリア時は `recordOwnChange` + `lastChangeCount` を更新する。テスト可能にするため `internal`（デフォルト可視性）にする。
+
+- [ ] **Step 1: Write the failing tests**
+
+`SecureClipboardTests/ClipboardMonitorTests.swift` の `@Suite(.serialized) struct ClipboardMonitorTests {` 内（既存テストの後、閉じ `}` の前）に追加:
+
+```swift
+    @Test func clearsWhenChangeCountMatches() async throws {
+        let monitor = ClipboardMonitor()
+        let pasteboard = NSPasteboard.general
+
+        pasteboard.clearContents()
+        pasteboard.setString("stale content", forType: .string)
+        let captured = pasteboard.changeCount
+
+        monitor.performClipboardClearIfUnchanged(capturedChangeCount: captured)
+
+        #expect(pasteboard.string(forType: .string) == nil)
+        // クリア書き込みは自己書き込みとして記録され、再検出されない
+        #expect(monitor.hasClipboardChanged(since: captured) == false)
+    }
+
+    @Test func doesNotClearWhenChangeCountStale() async throws {
+        let monitor = ClipboardMonitor()
+        let pasteboard = NSPasteboard.general
+
+        pasteboard.clearContents()
+        pasteboard.setString("old", forType: .string)
+        let stale = pasteboard.changeCount
+
+        // captured より後に新しい内容がコピーされた状況を再現
+        pasteboard.clearContents()
+        pasteboard.setString("new content", forType: .string)
+
+        monitor.performClipboardClearIfUnchanged(capturedChangeCount: stale)
+
+        // 最新の内容は消えない（no-op）
+        #expect(pasteboard.string(forType: .string) == "new content")
+    }
+
+    @Test func doesNotClearWhenAlreadyEmpty() async throws {
+        let monitor = ClipboardMonitor()
+        let pasteboard = NSPasteboard.general
+
+        pasteboard.clearContents()
+        let captured = pasteboard.changeCount
+
+        monitor.performClipboardClearIfUnchanged(capturedChangeCount: captured)
+
+        // 空のまま no-op（changeCount を無駄に変動させない）
+        #expect(pasteboard.changeCount == captured)
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --disable-sandbox --filter ClipboardMonitorTests`
+Expected: コンパイルエラー（`performClipboardClearIfUnchanged` not found）。
+
+- [ ] **Step 3: Implement the clear methods**
+
+`SecureClipboard/ClipboardMonitor.swift` の `func stop()` の直後（`private func scanText` の前）に追加:
+
+```swift
+    /// Clear the clipboard only if it hasn't changed since `capturedChangeCount`
+    /// and is not already empty. Records the clear as an own-change so the
+    /// monitor does not re-detect it (prevents an infinite clear loop).
+    func performClipboardClearIfUnchanged(capturedChangeCount: Int) {
+        let pasteboard = NSPasteboard.general
+        guard pasteboard.changeCount == capturedChangeCount else { return }
+        guard pasteboard.types?.isEmpty == false else { return }
+
+        pasteboard.clearContents()
+        let newChangeCount = pasteboard.changeCount
+        recordOwnChange(changeCount: newChangeCount)
+        lastChangeCount = newChangeCount
+        logger.info("Clipboard auto-cleared")
+    }
+
+    /// Schedule an auto-clear after `seconds`, keyed to the current changeCount.
+    private func scheduleClearIfEnabled(_ config: AppConfig) {
+        guard let seconds = config.clearClipboardAfterSeconds, seconds > 0 else { return }
+        let captured = NSPasteboard.general.changeCount
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) { [weak self] in
+            self?.performClipboardClearIfUnchanged(capturedChangeCount: captured)
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --disable-sandbox --filter ClipboardMonitorTests`
+Expected: PASS（既存2 + 新規3 = 5テスト）。
+
+注: `scheduleClearIfEnabled` はまだ呼び出されないため "unused" 警告が出る場合がある。Task 3 で呼び出しを追加するので問題ない。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add SecureClipboard/ClipboardMonitor.swift SecureClipboardTests/ClipboardMonitorTests.swift
+git commit -m "feat: add clipboard clear logic with changeCount guard"
+```
+
+---
+
+## Task 3: ポーリングループからクリアを予約する
+
+**Files:**
+- Modify: `SecureClipboard/ClipboardMonitor.swift`
+
+スケジュールは2箇所で呼ぶ。(1) `skipScanAppIdentifiers` で `continue` する前（スキャン除外アプリのコピーも古い内容を残さない対象にするため、`current` の count で予約）。(2) テキスト/画像処理の後（マスク後の最終 count で予約）。設定無効時は `scheduleClearIfEnabled` 内で早期 return するため副作用なし。
+
+このタスクはタイミング依存の非同期挙動のため、変更後は `swift build` でのコンパイル確認と手動検証で担保する（自動テストは Task 2 の同期ロジックでカバー済み）。
+
+- [ ] **Step 1: Add schedule call before the skipScan continue**
+
+`SecureClipboard/ClipboardMonitor.swift` の `start()` 内、skipScan ブロックを次のように変更する。変更前:
+
+```swift
+                    if config.shouldSkipScan(
+                        frontmostBundleId: sourceBundleId,
+                        pasteboardTypes: pasteboardTypes,
+                        nspasteboardSource: nspasteboardSource
+                    ) {
+                        Thread.sleep(forTimeInterval: 0.5)
+                        continue
+                    }
+```
+
+変更後:
+
+```swift
+                    if config.shouldSkipScan(
+                        frontmostBundleId: sourceBundleId,
+                        pasteboardTypes: pasteboardTypes,
+                        nspasteboardSource: nspasteboardSource
+                    ) {
+                        // Scan is skipped, but stale content should still auto-clear.
+                        self.scheduleClearIfEnabled(config)
+                        Thread.sleep(forTimeInterval: 0.5)
+                        continue
+                    }
+```
+
+- [ ] **Step 2: Add schedule call after text/image processing**
+
+同じ `if current != self.lastChangeCount, self.ownChangeCount != current {` ブロックの末尾、テキスト/画像処理の `} else if ... { ... }` チェーンの直後（このブロックを閉じる `}` の直前）に追加する。変更前の該当箇所:
+
+```swift
+                    } else if let imageData = pasteboard.data(forType: .tiff) ?? pasteboard.data(forType: .png),
+                              let image = NSImage(data: imageData) {
+                        let semaphore = DispatchSemaphore(value: 0)
+                        Task {
+                            await self.scanImage(image, sourceApp: sourceApp)
+                            semaphore.signal()
+                        }
+                        semaphore.wait()
+                    }
+                }
+                Thread.sleep(forTimeInterval: 0.5)
+```
+
+変更後（`}` の前に `scheduleClearIfEnabled` を追加）:
+
+```swift
+                    } else if let imageData = pasteboard.data(forType: .tiff) ?? pasteboard.data(forType: .png),
+                              let image = NSImage(data: imageData) {
+                        let semaphore = DispatchSemaphore(value: 0)
+                        Task {
+                            await self.scanImage(image, sourceApp: sourceApp)
+                            semaphore.signal()
+                        }
+                        semaphore.wait()
+                    }
+
+                    // Schedule auto-clear keyed to the post-scan changeCount
+                    // (covers external copies and SecureClipboard's own masked writes).
+                    self.scheduleClearIfEnabled(config)
+                }
+                Thread.sleep(forTimeInterval: 0.5)
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `swift build --disable-sandbox`
+Expected: ビルド成功、`scheduleClearIfEnabled` の unused 警告が消える。
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `swift test --disable-sandbox`
+Expected: 全テスト PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add SecureClipboard/ClipboardMonitor.swift
+git commit -m "feat: schedule clipboard auto-clear on clipboard changes"
+```
+
+---
+
+## Task 4: ドキュメントとデフォルト設定テンプレートを更新
+
+**Files:**
+- Modify: `SecureClipboard/MenuBarView.swift`
+- Modify: `README.md`
+
+- [ ] **Step 1: Update the defaultConfig template**
+
+`SecureClipboard/MenuBarView.swift` の `defaultConfig` 文字列を変更する。変更前:
+
+```swift
+    private let defaultConfig = """
+    {
+        "rules": [
+            {
+                "id": "@secretlint/secretlint-rule-preset-recommend"
+            }
+        ],
+        "patterns": [],
+        "skipScanAppIdentifiers": [],
+        "scanDelaySeconds": 0
+    }
+    """
+```
+
+変更後（`scanDelaySeconds` の行末にカンマを追加し、新キーを追記）:
+
+```swift
+    private let defaultConfig = """
+    {
+        "rules": [
+            {
+                "id": "@secretlint/secretlint-rule-preset-recommend"
+            }
+        ],
+        "patterns": [],
+        "skipScanAppIdentifiers": [],
+        "scanDelaySeconds": 0,
+        "clearClipboardAfterSeconds": null
+    }
+    """
+```
+
+- [ ] **Step 2: Update README config example**
+
+`README.md` の最初の config 例（67-82行付近）の `"scanDelaySeconds": 0` を次のように変更する。変更前:
+
+```json
+    "scanDelaySeconds": 0
+}
+```
+
+変更後:
+
+```json
+    "scanDelaySeconds": 0,
+    "clearClipboardAfterSeconds": null
+}
+```
+
+- [ ] **Step 3: Add README section for the new option**
+
+`README.md` の `### scanDelaySeconds` セクション（116-124行）の直後、`### skipScanAppIdentifiers` の前に新セクションを追加する:
+
+```markdown
+### clearClipboardAfterSeconds
+
+Seconds after the last clipboard change before the clipboard is automatically cleared. Default: `null` (disabled). This helps avoid accidentally pasting stale content copied earlier. The timer effectively resets on every clipboard change: if you copy something new within the interval, only the latest content is cleared. Set to `null` or `0` to disable.
+
+```json
+{
+    "clearClipboardAfterSeconds": 60
+}
+```
+```
+
+- [ ] **Step 4: Build to verify nothing broke**
+
+Run: `swift build --disable-sandbox`
+Expected: ビルド成功。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add SecureClipboard/MenuBarView.swift README.md
+git commit -m "docs: document clearClipboardAfterSeconds option"
+```
+
+---
+
+## Manual Verification (実装完了後)
+
+`.app` をビルドして実機確認する: `bash scripts/build-app.sh`
+
+設定 `~/.config/secure-clipboard/config.json` に `"clearClipboardAfterSeconds": 10` を入れて以下を確認:
+
+1. **基本クリア**: 何かをコピー → 10秒後にクリップボードが空になる（`pbpaste` が空）。
+2. **タイマーリセット**: コピー → 5秒後に別の内容をコピー → 最初の内容は途中で消えず、最新の内容が（その10秒後に）クリアされる。
+3. **ループ防止（最重要）**: 機能ON・何もコピーせず放置 → 無限クリアループが起きず、Console.app のログに `Clipboard auto-cleared` が繰り返し出力されない。
+4. **無効時**: `null` または未設定 → 自動クリアが一切発生しない。
+
+---
+
+## Self-Review
+
+- **Spec coverage**:
+  - config仕様（`clearClipboardAfterSeconds: Double?`, default nil, 0/負値/null は無効）→ Task 1 + `scheduleClearIfEnabled` の `seconds > 0` ガード。
+  - スケジュール位置（skipScan continue 前 + マスク後の最終 count）→ Task 3 の2箇所の呼び出し。
+  - 自己クリアループ防止（recordOwnChange + 空 no-op）→ Task 2 の `performClipboardClearIfUnchanged`。
+  - マスク済み内容の扱い（post-mask count をキー）→ Task 3 Step 2。
+  - copyOriginalText 据え置き → 本プランでは `StatusState` を変更しないため自動的に維持。
+  - 検証3項目 → Manual Verification に反映。
+- **Placeholder scan**: プレースホルダなし。全ステップに実コードを記載。
+- **Type consistency**: `performClipboardClearIfUnchanged(capturedChangeCount:)`, `scheduleClearIfEnabled(_:)`, `clearClipboardAfterSeconds` の名称・シグネチャは Task 1〜3 で一貫。`recordOwnChange(changeCount:)` / `lastChangeCount` / `logger` は既存 ClipboardMonitor のメンバ。

--- a/docs/superpowers/specs/2026-05-31-clipboard-auto-clear-design.md
+++ b/docs/superpowers/specs/2026-05-31-clipboard-auto-clear-design.md
@@ -1,0 +1,74 @@
+# クリップボード自動クリア機能 設計
+
+## 背景と目的
+
+コピー&ペースト時に、過去にコピーした古い内容を誤ってペーストしてしまうことがある。これを防ぐため、最後のコピー（クリップボード変更）から一定時間が経過したらクリップボードを自動でクリアするオプションを追加する。
+
+1Password の自動クリア（90秒）と同じ「アイドルベース」のモデルを採用する。既存の `copyOriginalText` が持つ90秒自動クリアの仕組みを、クリップボード全体に広げる位置づけ。
+
+## クリアのモデル
+
+- 「最後のコピーからN秒後」モデル（アイドルベース）。
+- クリップボードが変更されるたびにタイマーが実質的にリセットされ、最後の変更からN秒経過したらクリアする。
+- N秒以内に新しいコピーがあれば、古い予約は無効化され、最新の内容に対して新たに予約される。
+
+## config 仕様
+
+`~/.config/secure-clipboard/config.json` に新しいキーを追加する。
+
+- キー名: `clearClipboardAfterSeconds`
+- 型: `Double?`
+- デフォルト: `nil`（機能無効）
+- 挙動: 正の値が設定されたとき、その秒数後にクリップボードを自動クリアする。`nil`・`0`・負値はすべて「無効」として扱う。
+
+`AppConfig` に `var clearClipboardAfterSeconds: Double?` を追加し、`AppConfig.default` と `load()` のフォールバックに反映する（既存の `scanDelaySeconds` と同じ流儀）。
+
+`MenuBarView` の `defaultConfig` テンプレート文字列、および README / CLAUDE.md の config 例にも追記する。
+
+UI（メニューのトグルや手動クリアボタン）は今回追加しない。設定は config.json のみで行う。
+
+## スケジュール位置（ClipboardMonitor）
+
+実装は `ClipboardMonitor` のポーリングループ内で行う（アプローチA）。
+
+- 新しい変更を検出したブロック内で、クリアを予約する。
+- 予約は `skipScanAppIdentifiers` による `continue` の**前**に行う。スキャン除外対象のアプリからのコピーも「古い内容を残さない」対象に含めるため。スキャン除外とクリア除外は別概念として扱い、結合しない。
+- 予約はスキャン/マスク処理の**後**、つまり処理サイクルの最後に、その時点の `pasteboard.changeCount` を捕捉して行う。これにより外部コピーだけでなく SecureClipboard 自身がマスク・破棄で書き換えた内容も対象になる。
+- 発火は `DispatchQueue.main.asyncAfter(deadline: .now() + N)` を使う。発火時に `pasteboard.changeCount == 捕捉値` の場合のみ `clearContents()` を実行する。一致しない場合（その後にコピーされた）は何もしない（no-op）。
+- この changeCount ガード方式により、タイマーのキャンセル機構（DispatchWorkItem / Timer）は不要。古い予約は changeCount 不一致で自然に no-op になる。`copyOriginalText` と同じイディオム。
+
+実装メモ: `skipScanAppIdentifiers` のスキップは現状 `continue` で早期離脱するため、クリア予約をそのブロックより前に移動する、もしくはクリア予約を専用ヘルパに切り出して両経路から呼べるようにする。
+
+## 自己クリアループ防止（最重要）
+
+`clearContents()` は `changeCount` を増加させる。何も対策しないと「クリア → 監視が新しい変更として検出 → 再予約 → クリア」が N秒ごとに無限に繰り返され、changeCount が変動し続けて他のクリップボードマネージャを妨害する恐れがある。
+
+対策:
+
+1. クリア実行後の新しい `changeCount` を、既存の `onCopy` / `recordOwnChange` 経路で自己書き込みとして記録する。監視ループはこれを無視するため、再予約されない。
+2. 加えて、クリア発火時にクリップボードが既に空（対象タイプのデータが存在しない）であれば何もしない。
+
+## マスク済み内容の扱い
+
+スケジュールを処理サイクルの最後・マスク後の `changeCount` に対して行うため、外部からコピーされた内容だけでなく、SecureClipboard 自身がマスクした内容も N秒後にクリアされる。元の外部 `changeCount` に対して予約すると、マスクで count が変わりガードに失敗してマスク内容がクリアされないため、必ず処理後の count をキーにする。
+
+## 既存の copyOriginalText との関係
+
+`copyOriginalText` / `copyOriginalImage` の90秒自動クリアはそのまま据え置く。これは「意図的に元テキストを一時的に露出する」専用機能であり、固有のタイムアウトを持つ。今回の `clearClipboardAfterSeconds` には連動させず、独立した機能として維持する。
+
+なお `copyOriginalText` のコピーは `recordOwnChange` で自己書き込みとして記録されるため、監視ループは新しい変更として検出せず、今回のクリア予約の対象にもならない。したがって両機能は干渉しない。
+
+## テスト / 検証
+
+CLAUDE.md の方針に従い、`swift test --disable-sandbox` と手動確認を行う。
+
+自動テストの方針:
+
+- `NSPasteboard.general` を書き込むテストは `@Suite(.serialized)` でラップして直列実行する（プロジェクト規約）。
+- changeCount ガードのロジック（「捕捉した count と一致するときだけクリア」「空なら no-op」）を検証できる単位に切り出してテストする。
+
+手動検証項目:
+
+1. `clearClipboardAfterSeconds` に N を設定 → 何かをコピー → N秒後にクリップボードが空になる。
+2. コピー → N秒以内に再コピー → 最新の内容のみがクリアされ、途中で古い内容が消えない。
+3. 機能ON・何もコピーせず放置 → 無限クリアループが起きず、`changeCount` が安定している（ループバグ検出。最重要）。


### PR DESCRIPTION
## Summary

Add a `clearClipboardAfterSeconds` config option that automatically clears the clipboard N seconds after the last clipboard change. This prevents accidentally pasting stale content copied earlier. It uses the same idle-based model as 1Password's auto-clear.

- Add `clearClipboardAfterSeconds: Double?` to `AppConfig` (default `null` = disabled, same style as `scanDelaySeconds`).
- Add changeCount-guarded clear logic to `ClipboardMonitor`:
  - `performClipboardClearIfUnchanged(capturedChangeCount:)`: clears via `clearContents()` only if the changeCount still matches the captured value and the pasteboard is non-empty. The clear write is recorded via `recordOwnChange` so the monitor does not re-detect it, preventing an infinite clear loop.
  - `scheduleClearIfEnabled(_:)`: when `clearClipboardAfterSeconds > 0`, schedules the clear via `DispatchQueue.main.asyncAfter`.
- Schedule from two points in the polling loop: before the `skipScanAppIdentifiers` early `continue` (skip-listed apps' copies are still auto-cleared), and after the text/image scan (keyed to the post-mask changeCount).
- Document the option in README and the default config template.

The timer effectively resets on every clipboard change: copying something new within the interval means only the latest content is cleared. It does not affect "Copy Original Text" / "Copy Original Image", which keep their own fixed 90-second window.

## Design / Plan docs

- `docs/superpowers/specs/2026-05-31-clipboard-auto-clear-design.md`
- `docs/superpowers/plans/2026-05-31-clipboard-auto-clear.md`

## Test Plan

- [x] `swift test --disable-sandbox --filter "ClipboardMonitorTests|AppConfig"` → 31 tests pass
- [x] `swift test --disable-sandbox --no-parallel` → 54 tests pass (3 consecutive runs)
- [ ] Manual: set `clearClipboardAfterSeconds: 10` → copy → clipboard is empty after 10s
- [ ] Manual: copy → copy again within 10s → only the latest content is cleared
- [ ] Manual: feature on, left idle → no infinite clear loop (changeCount stays stable)

Note: under the default parallel test run, `ClipboardMonitorTests` and `StatusStatePasteboardTests` contend over the process-shared `NSPasteboard.general` (each is `.serialized` internally, but the two suites run in parallel). This is a pre-existing flakiness present on `main`, unrelated to this change; the suite passes reliably with `--no-parallel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
